### PR TITLE
Fixing between when all values are ground

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -4480,7 +4480,7 @@ int b_reverse(int arglist, int rest)
 
 int b_between(int arglist, int rest)
 {
-    int n, arg1, arg2, arg3, save1, save2, save3, low, high;
+    int n, arg1, arg2, arg3, save1, save2, save3, low, high, betweenval;
 
     n = length(arglist);
     if (n == 3) {
@@ -4503,6 +4503,16 @@ int b_between(int arglist, int rest)
 	save3 = ac;
 	low = get_int(arg1);
 	high = get_int(arg2);
+
+	if (groundp(arg3)) {
+ 	   betweenval = get_int(arg3);
+           if (betweenval >= low && betweenval <= high) {
+	    if (prove_all(rest, sp) == YES)
+		return (YES);
+	   }			   
+	   return (NO);
+    	}
+	
 	while (low <= high) {
 	    //printf("%d",low);
 	    unify(arg3, makeint(low));

--- a/data.c
+++ b/data.c
@@ -1592,6 +1592,9 @@ int groundp(int addr)
     else if (atomp(addr))
 	return (1);
 
+    else if (numberp(addr))
+	return (1);
+
     else if (groundp(cadr(addr)) && groundp(caddr(addr)))
 	return (1);
 

--- a/tests/verify.pl
+++ b/tests/verify.pl
@@ -297,4 +297,10 @@ test(dot) :-
     M = .(a,[b,c]),
     verify(M = [a,b,c]).
 
+test(between) :-
+    verify(between(1,10,3)),
+    verify(not(between(1,10,11))),
+    between(1,1,B),
+    verify(B = 1).
+
 :- alltest,write('All tests are done'),nl.


### PR DESCRIPTION
Hi, I noticed a bug with the between inbuilt predicate and decided to fix it (partly to learn how things are put together in the code).

The issue is that if you have all the variables to between/3 as integers, then nprolog says 'no' but should say 'yes'. 

eg: `between(1,10,3)` should be 'yes', but is not. 

I added in the functionality to the built in and found a bug where `ground/1` crashes nprolog if you try using an integer (floats seem to work fine). I fixed that issue as well. 

eg: `ground(3)` causes a crash, `ground(3.142)` works... Other cases seem to work ok. 